### PR TITLE
Remove Summer 2022 roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ Good luck and happy hunting :tada:!
 
 | Company Name | Position | Location | Visa Support | Notes |
 |--------------|----------|----------|--------------|-------|
-| [Apple](https://jobs.apple.com/en-us/details/200253195/software-engineering-internship?team=STDNT) | SWE | Multiple locations | | Not sure if this is for Winter |
+| [Apple](https://jobs.apple.com/en-us/details/200253195/software-engineering-internship?team=STDNT) | SWE | Multiple locations | | Not sure if this is for Winter. |
 | [Cambly](https://jobs.lever.co/cambly/a85a325b-1992-421b-8e62-ea487a8fba0b) | SWE | San Francisco | | |
 | [Cisco](https://jobs.cisco.com/jobs/SearchJobs/?21178=%5B169482%5D&21178_format=6020&21180=%5B33821095%2C165%5D&21180_format=6022&21181=%5B201%2C187%5D&21181_format=6023&21183=%5B34442672%2C174%2C175%2C176%2C177%2C178%2C179%2C180%2C211849%2C181%5D&21183_format=6024&listFilterMode=1) | SRE, Full Stack, Product | San Francisco | | |
-| [Citadel](https://www.citadel.com/careers/details/software-engineer-intern-us/) | SWE | Multiple locations | | Same posting for Winter/Summer/Fall |
+| [Citadel](https://www.citadel.com/careers/details/software-engineer-intern-us/) | SWE | Multiple locations | | Same posting for Winter/Summer/Fall. |
 | [Cruise](https://www.getcruise.com/careers/jobs?department=2bGFusPlaxpzEPHPIb2QLK&search=intern) | Multiple positions | Multiple locations | | |
 | [Google (US)](https://careers.google.com/jobs/results/111556027477828294/) | SWE | Multiple locations | | Application Deadline: **August 20th 2021**|
 | [Google (Canada)](https://careers.google.com/jobs/results/85238117155381958/?hl=fr_FR) | SWE | Waterloo, Montreal | | |
-| [Intel](https://jobs.intel.com/ShowJob/Id/2872320/Software-Engineer-Undergraduate-Intern) | SWE | Multiple locations | | Not sure if this is for Winter |
+| [Intel](https://jobs.intel.com/ShowJob/Id/2872320/Software-Engineer-Undergraduate-Intern) | SWE | Multiple locations | | Not sure if this is for Winter. |
 | [Konrad](https://boards.greenhouse.io/konradgroup/jobs/4581834003?gh_src=56dbf40d3us) | SWE | Toronto | | |
-| [Microsoft (US)](https://careers.microsoft.com/students/us/en/job/1085294/Software-Engineering-Intern-Opportunities) | SWE | Multiple locations | | Not sure if this is for Winter |
+| [Microsoft (US)](https://careers.microsoft.com/students/us/en/job/1085294/Software-Engineering-Intern-Opportunities) | SWE | Multiple locations | | Not sure if this is for Winter. |
 | [Microsoft (Canada)](https://careers.microsoft.com/us/en/job/1116547/Software-Engineer-Winter-Co-op-Intern-Opportunities%E2%80%AF%E2%80%AF) | SWE | Vancouver, Canada | | |
-| [Palantir](https://jobs.lever.co/palantir/5d5ff415-8219-4e0c-9930-2d5919e90354) | SWE | London, New York, Palo Alto, Washington | | Asks for start date |
-| [Playstation (US & Canada)](https://boards.greenhouse.io/sonyinteractiveentertainmentplaystation/jobs/3316438) | SWE, SDET, multiple other jobs | Waterloo ON, US (multiple locations) | | Asks if you are interested in Summer 2022 |
-| [Robinhood](https://robinhood.com/us/en/careers/openings/?gh_src=ed898e781us) | Multiple Positions | Menlo Park | | Scroll down to University. Same posting for Winter/Summer/Fall |
+| [Palantir](https://jobs.lever.co/palantir/5d5ff415-8219-4e0c-9930-2d5919e90354) | SWE | London, New York, Palo Alto, Washington | | Flexible start date. |
+| [Playstation (US & Canada)](https://boards.greenhouse.io/sonyinteractiveentertainmentplaystation/jobs/3316438) | SWE, SDET, multiple other jobs | Waterloo ON, US (multiple locations) | | Asks if you are interested in Summer 2022. |
+| [Robinhood](https://robinhood.com/us/en/careers/openings/?gh_src=ed898e781us) | Multiple Positions | Menlo Park | | Scroll down to University. Same posting for Winter/Summer/Fall. |
 | [Sigma](https://boards.greenhouse.io/sigmacomputing/jobs/4510690003) | SWE | San Francisco | | |
 
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Good luck and happy hunting :tada:!
 
 | Company Name | Position | Location | Visa Support | Notes |
 |--------------|----------|----------|--------------|-------|
-| [Amazon (US)](https://www.amazon.jobs/en/jobs/1557929/software-development-engineer-internship-summer-2022-us) | SWE | Multiple locations | | |
-| [Amazon (Canada)](https://www.amazon.jobs/en/jobs/1559866/software-development-engineer-intern-summer-2022-canada) | SWE | Multiple locations | | |
 | [Apple](https://jobs.apple.com/en-us/details/200253195/software-engineering-internship?team=STDNT) | SWE | Multiple locations | | |
 | [Cambly](https://jobs.lever.co/cambly/a85a325b-1992-421b-8e62-ea487a8fba0b) | SWE | San Francisco | | |
 | [Cisco](https://jobs.cisco.com/jobs/SearchJobs/?21178=%5B169482%5D&21178_format=6020&21180=%5B33821095%2C165%5D&21180_format=6022&21181=%5B201%2C187%5D&21181_format=6023&21183=%5B34442672%2C174%2C175%2C176%2C177%2C178%2C179%2C180%2C211849%2C181%5D&21183_format=6024&listFilterMode=1) | SRE, Full Stack, Product | San Francisco | | |

--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ Good luck and happy hunting :tada:!
 
 | Company Name | Position | Location | Visa Support | Notes |
 |--------------|----------|----------|--------------|-------|
-| [Apple](https://jobs.apple.com/en-us/details/200253195/software-engineering-internship?team=STDNT) | SWE | Multiple locations | | |
+| [Apple](https://jobs.apple.com/en-us/details/200253195/software-engineering-internship?team=STDNT) | SWE | Multiple locations | | Not sure if this is for Winter |
 | [Cambly](https://jobs.lever.co/cambly/a85a325b-1992-421b-8e62-ea487a8fba0b) | SWE | San Francisco | | |
 | [Cisco](https://jobs.cisco.com/jobs/SearchJobs/?21178=%5B169482%5D&21178_format=6020&21180=%5B33821095%2C165%5D&21180_format=6022&21181=%5B201%2C187%5D&21181_format=6023&21183=%5B34442672%2C174%2C175%2C176%2C177%2C178%2C179%2C180%2C211849%2C181%5D&21183_format=6024&listFilterMode=1) | SRE, Full Stack, Product | San Francisco | | |
-| [Citadel](https://www.citadel.com/careers/details/software-engineer-intern-us/) | SWE | Multiple locations | | |
+| [Citadel](https://www.citadel.com/careers/details/software-engineer-intern-us/) | SWE | Multiple locations | | Same posting for Winter/Summer/Fall |
 | [Cruise](https://www.getcruise.com/careers/jobs?department=2bGFusPlaxpzEPHPIb2QLK&search=intern) | Multiple positions | Multiple locations | | |
 | [Google (US)](https://careers.google.com/jobs/results/111556027477828294/) | SWE | Multiple locations | | Application Deadline: **August 20th 2021**|
 | [Google (Canada)](https://careers.google.com/jobs/results/85238117155381958/?hl=fr_FR) | SWE | Waterloo, Montreal | | |
-| [Intel](https://jobs.intel.com/ShowJob/Id/2872320/Software-Engineer-Undergraduate-Intern) | SWE | Multiple locations | | |
+| [Intel](https://jobs.intel.com/ShowJob/Id/2872320/Software-Engineer-Undergraduate-Intern) | SWE | Multiple locations | | Not sure if this is for Winter |
 | [Konrad](https://boards.greenhouse.io/konradgroup/jobs/4581834003?gh_src=56dbf40d3us) | SWE | Toronto | | |
-| [Microsoft (US)](https://careers.microsoft.com/students/us/en/job/1085294/Software-Engineering-Intern-Opportunities) | SWE | Multiple locations | | |
+| [Microsoft (US)](https://careers.microsoft.com/students/us/en/job/1085294/Software-Engineering-Intern-Opportunities) | SWE | Multiple locations | | Not sure if this is for Winter |
 | [Microsoft (Canada)](https://careers.microsoft.com/us/en/job/1116547/Software-Engineer-Winter-Co-op-Intern-Opportunities%E2%80%AF%E2%80%AF) | SWE | Vancouver, Canada | | |
-| [Palantir](https://jobs.lever.co/palantir/5d5ff415-8219-4e0c-9930-2d5919e90354) | SWE | London, New York, Palo Alto, Washington | | |
-| [Playstation (US & Canada)](https://boards.greenhouse.io/sonyinteractiveentertainmentplaystation/jobs/3316438) | SWE, SDET, multiple other jobs | Waterloo ON, US (multiple locations) | | |
-| [Robinhood](https://robinhood.com/us/en/careers/openings/?gh_src=ed898e781us) | Multiple Positions | Menlo Park | | Scroll down to University |
+| [Palantir](https://jobs.lever.co/palantir/5d5ff415-8219-4e0c-9930-2d5919e90354) | SWE | London, New York, Palo Alto, Washington | | Asks for start date |
+| [Playstation (US & Canada)](https://boards.greenhouse.io/sonyinteractiveentertainmentplaystation/jobs/3316438) | SWE, SDET, multiple other jobs | Waterloo ON, US (multiple locations) | | Asks if you are interested in Summer 2022 |
+| [Robinhood](https://robinhood.com/us/en/careers/openings/?gh_src=ed898e781us) | Multiple Positions | Menlo Park | | Scroll down to University. Same posting for Winter/Summer/Fall |
 | [Sigma](https://boards.greenhouse.io/sigmacomputing/jobs/4510690003) | SWE | San Francisco | | |
 
 


### PR DESCRIPTION
there are others that are kinda unclear too, but i found
- palantir -> lets u choose start date
- robinhood -> lets u choose season (winter, summer, fall)
- citadel -> lets u choose season (winter/spring, summer, fall)
- playstation -> asks if you are interested in summer 2022
- microsoft (us) -> not sure